### PR TITLE
Replaced extract-zip with manual unzip method for hanging issue on No…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,22 +6,7 @@
     "": {
       "dependencies": {
         "archiver": "^6.0.0",
-        "extract-zip": "^2.0.1"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "20.5.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.8.tgz",
-      "integrity": "sha512-eajsR9aeljqNhK028VG0Wuw+OaY5LLxYmxeoXynIoE6jannr9/Ucd1LL0hSSoafk5LTYG+FfqsyGt81Q6Zkybw==",
-      "optional": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
+        "yauzl": "^2.10.0"
       }
     },
     "node_modules/archiver": {
@@ -187,47 +172,12 @@
         "node": ">= 10"
       }
     },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
       }
     },
     "node_modules/fd-slicer": {
@@ -247,20 +197,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -398,11 +334,6 @@
         "node": "*"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -436,15 +367,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "archiver": "^6.0.0",
-    "extract-zip": "^2.0.1"
+    "yauzl": "^2.10.0"
   }
 }

--- a/packer.mjs
+++ b/packer.mjs
@@ -2,9 +2,37 @@
 import pako from './pako.js';
 import fs from 'fs';
 import { createInterface } from 'readline';
-import extract from 'extract-zip'
+import yauzl from 'yauzl'
 import archiver from 'archiver'
 import path from 'path';
+
+// Unzip a Factorio save (`zipPath`) into `destDir`, writing every entry to disk.
+function extractZip(zipPath, destDir) {
+  return new Promise((resolve, reject) => {
+    yauzl.open(zipPath, { lazyEntries: true }, (err, zip) => {
+      if (err) return reject(err);
+      zip.on('error', reject);
+      zip.on('end', resolve);
+      zip.on('entry', (entry) => {
+        const outPath = path.join(destDir, entry.fileName);
+        if (entry.fileName.endsWith('/')) { fs.mkdirSync(outPath, { recursive: true }); return zip.readEntry(); }
+        fs.mkdirSync(path.dirname(outPath), { recursive: true });
+        const stored = entry.compressionMethod === 0;
+        zip.openReadStream(entry, stored ? {} : { decompress: false }, (e, rs) => {
+          if (e) return reject(e);
+          const parts = [];
+          rs.on('data', (c) => parts.push(c));
+          rs.on('end', () => {
+            const raw = Buffer.concat(parts);
+            fs.writeFileSync(outPath, stored ? raw : Buffer.from(pako.inflateRaw(raw)));
+            zip.readEntry();
+          });
+        });
+      });
+      zip.readEntry();
+    });
+  });
+}
 
 // Thanks to u/KimJonhUnsSon which posted a solution for this on reddit
 // https://www.reddit.com/r/factorio/comments/rlprxh/text_tutorial_for_reenabling_achievements_after/
@@ -54,7 +82,7 @@ async function main() {
     // if save location supported from the switch statement
     savegames = fs.readdirSync(path.join(gamePath, 'saves'));
     savegames = savegames.filter(file => file.toLowerCase().endsWith('.zip'));
-  } 
+  }
   catch(e)
   {
     // if save location not supported from switch statement
@@ -101,7 +129,7 @@ async function main() {
     // unzip savegame
     const scriptDirectoryPath = fs.realpathSync(process.cwd()); 
 
-    await extract('./temp/savegame.zip', { dir: scriptDirectoryPath+'/temp' })
+    await extractZip('./temp/savegame.zip', scriptDirectoryPath+'/temp')
 
     // copy all "*.dat{0-9}[0-9]" files to input folder
     var files = await fs.readdirSync(`./temp/${savegame.replace('.zip', '')}`);


### PR DESCRIPTION
…de 22/24.

Extract-zip's streaming inflate didn't finish decompressing level-init.dat using node 22/24, so the extraction was failing. Replaced the 'extract()' call with a 'extractZip()' helper function that reads each zip entry's raw byte data (yauzl) and then inflates them using pako.

Added yauzl as a direct dependency instead of relying on extract-zip to install it as a dependency. Removed extract-zip dependency as it's no longer used.